### PR TITLE
add anonymization functionality to not post your strava name on discord

### DIFF
--- a/discord-strava/commands/set.rb
+++ b/discord-strava/commands/set.rb
@@ -14,6 +14,7 @@ module DiscordStrava
             "Activities for team #{command.team.guild_name} display *#{command.team.units_s}*.",
             "Activity fields are *#{command.team.activity_fields_s}*.",
             "Maps for team #{command.team.guild_name} are *#{command.team.maps_s}*.",
+            "Posts will #{command.team.anonymize? ? '' : 'not '}be anonymized.",
             "Your activities will #{command.user.sync_activities? ? '' : 'not '}sync.",
             "Your private activities will #{command.user.private_activities? ? '' : 'not '}be posted.",
             "Your followers only activities will #{command.user.followers_only_activities? ? '' : 'not '}be posted."
@@ -78,6 +79,11 @@ module DiscordStrava
               logger.info "SET: #{command.team} - maps set to #{command.team.maps}"
               "Maps for team #{command.team.guild_name} are#{changed ? ' now' : ''} *#{command.team.maps_s}*."
             end
+          when 'anonymize'
+            changed = v && command.team.anonymize != v
+            command.team.update_attributes!(anonymize: v) unless v.nil?
+            logger.info "SET: #{command.team} - anonymize set to #{command.team.anonymize}"
+            "Names in posts for team #{command.team.guild_name} will #{changed ? (command.team.anonymize? ? ' now' : ' no longer') : } be obscured in activity posts."
           else
             "Invalid setting #{k}, type `help` for instructions."
           end

--- a/discord-strava/models/team.rb
+++ b/discord-strava/models/team.rb
@@ -22,6 +22,8 @@ class Team
   field :units, type: String, default: 'mi'
   validates_inclusion_of :units, in: %w[mi km both]
 
+  field :anonymize, type: Boolean, default: false
+
   field :activity_fields, type: Array, default: ['Default']
   validates :activity_fields, array: { presence: true, inclusion: { in: ActivityFields.values } }
 

--- a/discord-strava/models/user_activity.rb
+++ b/discord-strava/models/user_activity.rb
@@ -88,7 +88,7 @@ class UserActivity < Activity
 
   def to_discord_embed
     result = {}
-    result[:title] = name
+    result[:title] = user.team.anonymize ? 'New Activity!' : name
     result[:url] = strava_url
     result[:description] = ["#{user.discord_mention} on #{start_date_local_s}", description].compact.join("\n\n")
     if map && map.has_image?


### PR DESCRIPTION
I have a group of people that I share common interests with but would not like to have my name from strava posted in discord as the title of the card. You already post the discord user in the body of the activity, which is plenty of info.

I'm not a ruby dev, nor do I know how to write a test in ruby for the TDD approach suggested in the contribution guidelines, nor did I run the style fixer. I don't have Ruby tools installed on my dev machine and I'm not interested in having them. This is just the simplest way I knew to communicate the feature I would like to have.

Since you are using mongo, I think the nonexistent anonymize value on the team would evaluate to falsey and thus default to the current state of not anonymizing.

I'm happy to subscribe if my name isn't in discord, but in the current state I cannot use the bot.