### PR TITLE
Return a 1x1 transparent pixel instead of 404/403 for expired/missing maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/12: Return a 1x1 transparent pixel instead of a 404/403 error when activity maps are not found or have expired - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Port per-channel settings from slack-strava — add `Channel` model, `set activities` command to filter activity types per channel, and per-channel maps/units/fields/userlimit - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/11: Upgrade to Ruby 4.0.2 - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/07: Fixed `Stripe::StripeObject#method_missing` error by replacing `customer.subscriptions` with `Stripe::Subscription.list` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/api/endpoints/maps_endpoint.rb
+++ b/discord-strava/api/endpoints/maps_endpoint.rb
@@ -3,6 +3,11 @@ module Api
     class MapsEndpoint < Grape::API
       content_type :png, 'image/png'
 
+      # 1x1 transparent PNG pixel returned when a map is not available.
+      PIXEL_PNG = Base64.decode64(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAABjE+ibYAAAAASUVORK5CYII='
+      ).freeze
+
       namespace :maps do
         desc 'Redirect to the map URI.'
         params do
@@ -12,16 +17,19 @@ module Api
           user_agent = headers['User-Agent'] || 'Unknown User-Agent'
           activity = UserActivity.where('map._id' => BSON::ObjectId(params[:id])).first
           unless activity
-            Api::Middleware.logger.debug "Map #{params[:id]} for #{user_agent}, not found (404)."
-            error!('Not Found', 404)
+            Api::Middleware.logger.info "Map #{params[:id]} for #{user_agent}, not found, returning pixel."
+            content_type 'image/png'
+            next body Api::Endpoints::MapsEndpoint::PIXEL_PNG
           end
           if activity.hidden?
-            Api::Middleware.logger.debug "Map png for #{activity.user}, #{activity} for #{user_agent}, hidden (403)."
-            error!('Access Denied', 403)
+            Api::Middleware.logger.info "Map png for #{activity.user}, #{activity} for #{user_agent}, hidden, returning pixel."
+            content_type 'image/png'
+            next body Api::Endpoints::MapsEndpoint::PIXEL_PNG
           end
           unless activity.map&.has_image?
-            Api::Middleware.logger.debug "Map png for #{activity.user}, #{activity} for #{user_agent}, no map (404)."
-            error!('Map Not Found', 404)
+            Api::Middleware.logger.info "Map png for #{activity.user}, #{activity} for #{user_agent}, no map, returning pixel."
+            content_type 'image/png'
+            next body Api::Endpoints::MapsEndpoint::PIXEL_PNG
           end
           if (png = activity.map.cached_png)
             content_type 'image/png'

--- a/spec/api/endpoints/maps_endpoint_spec.rb
+++ b/spec/api/endpoints/maps_endpoint_spec.rb
@@ -5,10 +5,11 @@ describe Api::Endpoints::MapsEndpoint do
 
   context 'maps' do
     context 'without an activity' do
-      it '404s' do
+      it 'returns a pixel' do
         get '/api/maps/5abd07019b0b58f119c1bbaa.png'
-        expect(last_response.status).to eq 404
-        expect(JSON.parse(last_response.body)).to eq('error' => 'Not Found')
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['Content-Type']).to eq 'image/png'
+        expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
       end
     end
 
@@ -69,9 +70,11 @@ describe Api::Endpoints::MapsEndpoint do
       let(:user) { Fabricate(:user, private_activities: false) }
       let(:activity) { Fabricate(:user_activity, private: true, user: user) }
 
-      it 'does not return map' do
+      it 'returns a pixel' do
         get "/api/maps/#{activity.map.id}.png"
-        expect(last_response.status).to eq 403
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['Content-Type']).to eq 'image/png'
+        expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
       end
     end
 
@@ -83,9 +86,11 @@ describe Api::Endpoints::MapsEndpoint do
         activity.map.update_attributes!(summary_polyline: nil)
       end
 
-      it 'does not return map' do
+      it 'returns a pixel' do
         get "/api/maps/#{activity.map.id}.png"
-        expect(last_response.status).to eq 404
+        expect(last_response.status).to eq 200
+        expect(last_response.headers['Content-Type']).to eq 'image/png'
+        expect(last_response.body).to eq Api::Endpoints::MapsEndpoint::PIXEL_PNG
       end
     end
   end


### PR DESCRIPTION
Port of dblock/slack-strava#239.

When activity maps are unavailable (expired/purged, hidden/private, or no polyline), returns a 1x1 transparent PNG pixel instead of a 404/403 error — preventing broken image icons in Discord messages.

- Add `PIXEL_PNG` constant to `MapsEndpoint`
- Return pixel for: activity not found, activity hidden, no map image
- Update tests to assert 200 + correct content-type + pixel body