### PR TITLE
Fix brag! test to pass channel_id to to_discord

### DIFF
--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -108,7 +108,7 @@ describe UserActivity do
     it 'sends a message to the subscribed channel' do
       expect(Discord::Bot.instance).to receive(:send_message).with(
         user.channel_id,
-        activity.to_discord
+        activity.to_discord(user.channel_id)
       ).and_return('id' => '1', 'channel_id' => '2')
       expect(activity.brag!).to eq(message_id: '1', channel_id: '2')
     end


### PR DESCRIPTION
The brag! method calls to_discord(channel_id) with the user's channel_id,
but the test was matching against activity.to_discord (no args). When
to_discord(nil) != to_discord(channel_id), the mock's .with() constraint
didn't match, causing the generic stub from spec/support/team.rb to fire
and return {id: 'message_id', channel_id: 'channel_id'} instead.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
