### PR TITLE
Fix Discord access errors not disabling user sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/20: Fixed Discord access errors (Missing Access, Missing Permissions, Unknown Channel) not disabling user sync, and Unknown Message errors in rebrag not clearing the stored channel message - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Extended `stats` command to accept date expressions (`weekly`, `monthly`, `yearly`, `quarterly`, `since`, `between`, etc.) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Format dates without time in stats and leaderboard messages when the time component is midnight; use team timezone when parsing date expressions - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Automatically display pace for run/walk/swim/hike activities and speed for ride/bike activities when using default fields - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/user.rb
+++ b/discord-strava/models/user.rb
@@ -6,6 +6,11 @@ class User
   include Brag
 
   UNKNOWN_MEMBER_ERROR = 'Unknown Member (10007, 404)'.freeze
+  UNKNOWN_CHANNEL_ERROR = 'Unknown Channel (10003, 404)'.freeze
+  UNKNOWN_MESSAGE_ERROR = 'Unknown Message (10008, 404)'.freeze
+  MISSING_ACCESS_ERROR = 'Missing Access (50001, 403)'.freeze
+  MISSING_PERMISSIONS_ERROR = 'Missing Permissions (50013, 403)'.freeze
+  DISABLE_SYNC_ERRORS = [MISSING_ACCESS_ERROR, MISSING_PERMISSIONS_ERROR, UNKNOWN_CHANNEL_ERROR].freeze
 
   field :channel_id, type: String
   field :user_id, type: String

--- a/discord-strava/models/user_activity.rb
+++ b/discord-strava/models/user_activity.rb
@@ -80,7 +80,9 @@ class UserActivity < Activity
       update_attributes!(bragged_at: Time.now.utc, channel_message: rc)
       rc
     end
-  rescue Faraday::ForbiddenError => e
+  rescue DiscordStrava::Error => e
+    raise unless User::DISABLE_SYNC_ERRORS.include?(e.message)
+
     logger.warn "Bragging to #{user} failed, #{e.message}, disabling user sync."
     update_attributes!(bragged_at: Time.now.utc)
     user.update_attributes!(sync_activities: false)
@@ -97,6 +99,12 @@ class UserActivity < Activity
     rc = user.update!(to_discord(channel_message.channel_id), channel_message)
     update_attributes!(channel_message: rc)
     rc
+  rescue DiscordStrava::Error => e
+    raise unless e.message == User::UNKNOWN_MESSAGE_ERROR
+
+    logger.warn "Rebragging to #{user} failed, #{e.message}, clearing channel message."
+    update_attributes!(channel_message: nil)
+    nil
   end
 
   def unbrag!

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -113,12 +113,32 @@ describe UserActivity do
       expect(activity.brag!).to eq(message_id: '1', channel_id: '2')
     end
 
-    it 'disables user sync on access error' do
+    it 'disables user sync on missing access error' do
       expect(Discord::Bot.instance).to receive(:send_message).with(
         user.channel_id,
-        activity.to_discord
-      ).and_raise(Faraday::ForbiddenError.new('forbidden'))
-      expect { activity.brag! }.to raise_error(Faraday::ForbiddenError)
+        activity.to_discord(user.channel_id)
+      ).and_raise(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
+      expect { activity.brag! }.to raise_error(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
+      expect(activity.bragged_at).not_to be_nil
+      expect(user.reload.sync_activities).to be false
+    end
+
+    it 'disables user sync on missing permissions error' do
+      expect(Discord::Bot.instance).to receive(:send_message).with(
+        user.channel_id,
+        activity.to_discord(user.channel_id)
+      ).and_raise(DiscordStrava::Error, User::MISSING_PERMISSIONS_ERROR)
+      expect { activity.brag! }.to raise_error(DiscordStrava::Error, User::MISSING_PERMISSIONS_ERROR)
+      expect(activity.bragged_at).not_to be_nil
+      expect(user.reload.sync_activities).to be false
+    end
+
+    it 'disables user sync on unknown channel error' do
+      expect(Discord::Bot.instance).to receive(:send_message).with(
+        user.channel_id,
+        activity.to_discord(user.channel_id)
+      ).and_raise(DiscordStrava::Error, User::UNKNOWN_CHANNEL_ERROR)
+      expect { activity.brag! }.to raise_error(DiscordStrava::Error, User::UNKNOWN_CHANNEL_ERROR)
       expect(activity.bragged_at).not_to be_nil
       expect(user.reload.sync_activities).to be false
     end
@@ -185,6 +205,18 @@ describe UserActivity do
         expect(Discord::Bot.instance).not_to receive(:send_message)
         expect(activity.brag!).to be_nil
       end
+    end
+  end
+
+  context 'rebrag!' do
+    let(:team) { Fabricate(:team) }
+    let(:user) { Fabricate(:user, team:) }
+    let!(:activity) { Fabricate(:user_activity, user:, channel_message: Fabricate(:channel_message)) }
+
+    it 'clears channel message on unknown message error' do
+      expect(Discord::Bot.instance).to receive(:update_message).and_raise(DiscordStrava::Error, User::UNKNOWN_MESSAGE_ERROR)
+      expect(activity.rebrag!).to be_nil
+      expect(activity.reload.channel_message).to be_nil
     end
   end
 


### PR DESCRIPTION
## What


## Changes

  - `Missing Access (50001, 403)`
  - `Missing Permissions (50013, 403)`
  - `Unknown Channel (10003, 404)` — channel no longer exists
- **`User`**: Added named constants for all error strings plus `DISABLE_SYNC_ERRORS` array.
- **Tests**: Updated existing test (was raising `Faraday::ForbiddenError` directly, bypassing conversion) and added tests for Missing Permissions, Unknown Channel, and rebrag Unknown Message.