### PR TITLE
Re-enable sync for users when team is reactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/20: Re-enable sync for Strava-connected users when a team is reactivated after bot reinstall - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Fixed Discord access errors (Missing Access, Missing Permissions, Unknown Channel) not disabling user sync, and Unknown Message errors in rebrag not clearing the stored channel message - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Extended `stats` command to accept date expressions (`weekly`, `monthly`, `yearly`, `quarterly`, `since`, `between`, etc.) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Format dates without time in stats and leaderboard messages when the time component is midnight; use team timezone when parsing date expressions - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/team.rb
+++ b/discord-strava/models/team.rb
@@ -575,6 +575,7 @@ class Team
   def activated!
     return unless active? && (active_changed? || saved_change_to_active?)
 
+    users.connected_to_strava.where(sync_activities: false).update_all(sync_activities: true)
     inform_activated!
     update_info!
   end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -202,6 +202,27 @@ describe Team do
     end
   end
 
+  describe '#activated!' do
+    let!(:team) { Fabricate(:team, active: false) }
+    let!(:user) { Fabricate(:user, team:, sync_activities: false) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:inform_activated!)
+      allow_any_instance_of(described_class).to receive(:update_info!)
+    end
+
+    it 're-enables sync for connected users with strava when team is reactivated' do
+      user.update_attributes!(access_token: 'token')
+      team.update_attributes!(active: true)
+      expect(user.reload.sync_activities).to be true
+    end
+
+    it 'does not re-enable sync for users not connected to strava' do
+      team.update_attributes!(active: true)
+      expect(user.reload.sync_activities).to be false
+    end
+  end
+
   describe '#check_access' do
     let(:team) { Fabricate(:team) }
 


### PR DESCRIPTION
## What

When the bot is reinstalled to a guild, the existing `Team` is found and reactivated. Previously, users whose `sync_activities` had been disabled (e.g. due to Missing Access errors from the previous PR) were not automatically re-enabled — they had to manually run `/strada set sync on`.

## Changes

- Only affects users already connected to Strava (not disconnected users).
- Tests cover both the re-enable and the no-op for non-connected users.