### PR TITLE
Fix brag! re-raising Discord access errors after disabling user sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/26: Fixed `brag!` re-raising Discord access errors (Missing Access, Missing Permissions, Unknown Channel) after disabling user sync, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Fixed Discord access errors (Missing Access, Missing Permissions, Unknown Channel) not disabling user sync, and Unknown Message errors in rebrag not clearing the stored channel message - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Extended `stats` command to accept date expressions (`weekly`, `monthly`, `yearly`, `quarterly`, `since`, `between`, etc.) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Format dates without time in stats and leaderboard messages when the time component is midnight; use team timezone when parsing date expressions - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/user_activity.rb
+++ b/discord-strava/models/user_activity.rb
@@ -86,7 +86,7 @@ class UserActivity < Activity
     logger.warn "Bragging to #{user} failed, #{e.message}, disabling user sync."
     update_attributes!(bragged_at: Time.now.utc)
     user.update_attributes!(sync_activities: false)
-    raise e
+    nil
   rescue StandardError => e
     logger.warn "Bragging to #{user} failed, #{e.message}."
     raise e

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -118,7 +118,7 @@ describe UserActivity do
         user.channel_id,
         activity.to_discord(user.channel_id)
       ).and_raise(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
-      expect { activity.brag! }.to raise_error(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
+      expect(activity.brag!).to be_nil
       expect(activity.bragged_at).not_to be_nil
       expect(user.reload.sync_activities).to be false
     end
@@ -128,7 +128,7 @@ describe UserActivity do
         user.channel_id,
         activity.to_discord(user.channel_id)
       ).and_raise(DiscordStrava::Error, User::MISSING_PERMISSIONS_ERROR)
-      expect { activity.brag! }.to raise_error(DiscordStrava::Error, User::MISSING_PERMISSIONS_ERROR)
+      expect(activity.brag!).to be_nil
       expect(activity.bragged_at).not_to be_nil
       expect(user.reload.sync_activities).to be false
     end
@@ -138,7 +138,7 @@ describe UserActivity do
         user.channel_id,
         activity.to_discord(user.channel_id)
       ).and_raise(DiscordStrava::Error, User::UNKNOWN_CHANNEL_ERROR)
-      expect { activity.brag! }.to raise_error(DiscordStrava::Error, User::UNKNOWN_CHANNEL_ERROR)
+      expect(activity.brag!).to be_nil
       expect(activity.bragged_at).not_to be_nil
       expect(user.reload.sync_activities).to be false
     end


### PR DESCRIPTION
## Problem


## Fix


## Changes

- `discord-strava/models/user_activity.rb`: Return `nil` instead of re-raising after disabling sync
- `spec/models/user_activity_spec.rb`: Update 3 tests to expect `nil` return (not a raised error) after disabling sync