### PR TITLE
Fix inform_system and inform_guild_owner raising Discord errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/26: Fixed `inform_system!` and `inform_guild_owner!` re-raising Discord errors (e.g. Missing Access) during subscription expiry notifications, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Fixed `brag!` re-raising Discord access errors (Missing Access, Missing Permissions, Unknown Channel) after disabling user sync, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Fixed Discord access errors (Missing Access, Missing Permissions, Unknown Channel) not disabling user sync, and Unknown Message errors in rebrag not clearing the stored channel message - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Extended `stats` command to accept date expressions (`weekly`, `monthly`, `yearly`, `quarterly`, `since`, `between`, etc.) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/team.rb
+++ b/discord-strava/models/team.rb
@@ -196,14 +196,19 @@ class Team
   def inform_guild_owner!(message)
     return unless guild_owner_id || bot_owner_id
 
-    guild_owners.map do |id|
-      rc = Discord::Bot.instance.send_dm(id, message)
+    guild_owners.map { |id|
+      begin
+        rc = Discord::Bot.instance.send_dm(id, message)
 
-      {
-        message_id: rc['id'],
-        channel_id: rc['channel_id']
-      }
-    end
+        {
+          message_id: rc['id'],
+          channel_id: rc['channel_id']
+        }
+      rescue DiscordStrava::Error => e
+        logger.warn "Error DMing guild owner #{id} for #{self}: #{e.message}"
+        nil
+      end
+    }.compact
   end
 
   def inform_system!(message)
@@ -216,6 +221,9 @@ class Team
       message_id: rc['id'],
       channel_id: rc['channel_id']
     }
+  rescue DiscordStrava::Error => e
+    logger.warn "Error posting to system channel for #{self}: #{e.message}"
+    nil
   end
 
   def inform_everyone!(message)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -271,6 +271,53 @@ describe Team do
         expect(team.inform_guild_owner!('message')).to be_nil
       end
     end
+
+    context 'on a Discord error' do
+      let(:team) { Fabricate(:team, guild_owner_id: 'guild_owner_id', bot_owner_id: 'bot_owner_id') }
+
+      it 'skips the failed owner and still informs the others' do
+        allow(Discord::Bot.instance).to receive(:send_dm)
+          .with('guild_owner_id', 'message')
+          .and_raise(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
+        allow(Discord::Bot.instance).to receive(:send_dm)
+          .with('bot_owner_id', 'message')
+          .and_return('id' => 'm2', 'channel_id' => 'c2')
+        expect(team.inform_guild_owner!('message')).to eq [{ message_id: 'm2', channel_id: 'c2' }]
+      end
+
+      it 'returns an empty array when all owners fail' do
+        allow(Discord::Bot.instance).to receive(:send_dm)
+          .and_raise(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
+        expect(team.inform_guild_owner!('message')).to eq []
+      end
+    end
+  end
+
+  describe '#inform_system!' do
+    let(:team) { Fabricate(:team) }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:update_info!)
+      allow(team).to receive(:guild_info).and_return({ system_channel_id: 'system_channel_id' })
+    end
+
+    it 'sends a message to the system channel' do
+      allow(Discord::Bot.instance).to receive(:send_message)
+        .with('system_channel_id', 'message')
+        .and_return('id' => 'm1', 'channel_id' => 'system_channel_id')
+      expect(team.inform_system!('message')).to eq(message_id: 'm1', channel_id: 'system_channel_id')
+    end
+
+    it 'returns nil when there is no system channel' do
+      allow(team).to receive(:guild_info).and_return({})
+      expect(team.inform_system!('message')).to be_nil
+    end
+
+    it 'logs a warning and returns nil on a Discord error' do
+      allow(Discord::Bot.instance).to receive(:send_message)
+        .and_raise(DiscordStrava::Error, User::MISSING_ACCESS_ERROR)
+      expect(team.inform_system!('message')).to be_nil
+    end
   end
 
   describe '#prune_activities!' do


### PR DESCRIPTION
When subscription_expired tries to notify a team, Discord access errors propagate uncaught to expire_subscriptions rescue StandardError, generating spurious NewRelic error reports. Rescue DiscordStrava::Error in both methods, logging a warning and returning nil.