### PR TITLE
Fixed Team#subscription_info failing with NoMethodError on Stripe::Customer#sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Fixed `inform_system!` and `inform_guild_owner!` re-raising Discord errors (e.g. Missing Access) during subscription expiry notifications, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Fixed `brag!` re-raising Discord access errors (Missing Access, Missing Permissions, Unknown Channel) after disabling user sync, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Fixed Discord access errors (Missing Access, Missing Permissions, Unknown Channel) not disabling user sync, and Unknown Message errors in rebrag not clearing the stored channel message - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/team.rb
+++ b/discord-strava/models/team.rb
@@ -349,7 +349,7 @@ class Team
   end
 
   def stripe_customer_sources_info
-    stripe_customer.sources.map do |source|
+    Stripe::Customer.list_sources(stripe_customer.id).map do |source|
       "On file #{source.brand} #{source.object}, #{source.name} ending with #{source.last4}, expires #{source.exp_month}/#{source.exp_year}."
     end
   end

--- a/spec/discord-strava/commands/subscription_spec.rb
+++ b/spec/discord-strava/commands/subscription_spec.rb
@@ -47,7 +47,7 @@ describe DiscordStrava::Commands::Subscription do
           end
 
           it 'displays subscription info' do
-            card = customer.sources.first
+            card = Stripe::Customer.list_sources(customer.id).first
             current_period_end = Time.at(customer.subscriptions.first.current_period_end).strftime('%B %d, %Y')
             customer_info = [
               "Customer since #{Time.at(customer.created).strftime('%B %d, %Y')}.",
@@ -67,7 +67,7 @@ describe DiscordStrava::Commands::Subscription do
             end
 
             it 'displays subscription info' do
-              card = customer.sources.first
+              card = Stripe::Customer.list_sources(customer.id).first
               Time.at(customer.subscriptions.first.current_period_end).strftime('%B %d, %Y')
               customer_info = [
                 "Customer since #{Time.at(customer.created).strftime('%B %d, %Y')}.",
@@ -86,7 +86,6 @@ describe DiscordStrava::Commands::Subscription do
           end
 
           it 'displays subscription info' do
-            customer.sources.first
             current_period_end = Time.at(customer.subscriptions.first.current_period_end).strftime('%B %d, %Y')
             customer_info = [
               "Customer since #{Time.at(customer.created).strftime('%B %d, %Y')}.",


### PR DESCRIPTION
Fixes `Team#subscription_info` raising `NoMethodError: undefined method sources` on `Stripe::Customer` in stripe 13.5.1. The `sources` attribute is no longer returned on retrieved Customer objects. Use `Stripe::Customer.list_sources` instead.