### PR TITLE
Allow teams with an expired subscription to re-subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/02: Allow teams with an expired subscription to re-subscribe - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Fixed `inform_system!` and `inform_guild_owner!` re-raising Discord errors (e.g. Missing Access) during subscription expiry notifications, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Fixed `brag!` re-raising Discord access errors (Missing Access, Missing Permissions, Unknown Channel) after disabling user sync, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/api/endpoints/subscriptions_endpoint.rb
+++ b/discord-strava/api/endpoints/subscriptions_endpoint.rb
@@ -15,7 +15,7 @@ module Api
           team = Team.where(guild_id: params[:guild_id]).first || error!('Team Not Found', 404)
           Api::Middleware.logger.info "Creating a subscription for team #{team}."
           error!('Already Subscribed', 400) if team.subscribed?
-          error!('Customer Already Registered', 400) if team.stripe_customer_id
+          error!('Customer Already Registered', 400) if team.stripe_customer_id && !team.subscription_expired_at
           customer = Stripe::Customer.create(
             source: params[:stripe_token],
             plan: 'strada-yearly',

--- a/spec/api/endpoints/subscriptions_endpoint_spec.rb
+++ b/spec/api/endpoints/subscriptions_endpoint_spec.rb
@@ -48,6 +48,34 @@ describe Api::Endpoints::SubscriptionsEndpoint do
       end
     end
 
+    context 'team with an expired subscription' do
+      let!(:team) { Fabricate(:team, stripe_customer_id: 'old_customer_id', subscription_expired_at: Time.now.utc) }
+
+      it 'creates a subscription' do
+        expect(Stripe::Customer).to receive(:create).with(
+          source: 'token',
+          plan: 'strada-yearly',
+          email: 'foo@bar.com',
+          metadata: {
+            id: team._id,
+            guild_id: team.guild_id,
+            name: team.guild_name
+          }
+        ).and_return('id' => 'new_customer_id')
+        expect_any_instance_of(Team).to receive(:subscribed!).once
+        client.subscriptions._post(
+          guild_id: team.guild_id,
+          stripe_token: 'token',
+          stripe_token_type: 'card',
+          stripe_email: 'foo@bar.com'
+        )
+        team.reload
+        expect(team.subscribed).to be true
+        expect(team.subscribed_at).not_to be_nil
+        expect(team.stripe_customer_id).to eq 'new_customer_id'
+      end
+    end
+
     context 'existing team' do
       let!(:team) { Fabricate(:team) }
 

--- a/spec/integration/subscribe_spec.rb
+++ b/spec/integration/subscribe_spec.rb
@@ -36,6 +36,47 @@ describe 'Subscribe', :js, type: :feature do
       ENV.delete 'STRIPE_API_PUBLISHABLE_KEY'
     end
 
+    context 'for a team with an expired subscription' do
+      include_context 'team activation'
+
+      let!(:team) { Fabricate(:team, subscribed: false, stripe_customer_id: 'stripe_customer_id', subscription_expired_at: Time.now.utc) }
+
+      it 'subscribes team' do
+        visit "/subscribe?team_id=#{team.id}"
+        expect(find_by_id('messages')).to have_text("Subscribe team #{team.guild_name} for $19.99/yr.")
+
+        allow_any_instance_of(Team).to receive(:inform_everyone!)
+
+        find_by_id('subscribe', visible: true)
+
+        expect(Stripe::Customer).to receive(:create).and_return('id' => 'new_customer_id')
+
+        find_by_id('subscribeButton').click
+
+        sleep 1
+
+        stripe_iframe = all('iframe[name=stripe_checkout_app]').last
+        Capybara.within_frame stripe_iframe do
+          page.find_field('Email').set 'foo@bar.com'
+          page.find_field('Card number').client_set '4242 4242 4242 4242'
+          page.find_field('MM / YY').client_set '12/42'
+          page.find_field('CVC').set '123'
+          find('button[type="submit"]').click
+        end
+
+        sleep 5
+
+        find_by_id('subscribe', visible: false)
+        expect(find_by_id('messages')).to have_text("Team #{team.guild_name} successfully subscribed.\n\nThank you for your support!")
+
+        team.reload
+        expect(team.subscribed).to be true
+        expect(team.active).to be true
+        expect(team.stripe_customer_id).to eq 'new_customer_id'
+        expect(team.subscription_expired_at).to be_nil
+      end
+    end
+
     context 'for a team' do
       include_context 'team activation'
 

--- a/spec/integration/update_cc_spec.rb
+++ b/spec/integration/update_cc_spec.rb
@@ -46,6 +46,35 @@ describe 'Update cc', :js, type: :feature do
       end
     end
 
+    context 'an inactive team with an expired subscription' do
+      include_context 'team activation'
+
+      let!(:team) { Fabricate(:team, active: false, stripe_customer_id: 'stripe_customer_id', subscribed: false, subscription_expired_at: Time.now.utc) }
+
+      it 'updates cc' do
+        visit "/update_cc?team_id=#{team.id}"
+        expect(find('h1')).to have_text('Strada: Update Credit Card Info')
+        expect(find_by_id('messages')).to have_text("Click button to update the credit card for team #{team.guild_name}.")
+        customer = double
+        expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
+        expect(customer).to receive(:source=)
+        expect(customer).to receive(:save)
+        click_button 'Update Credit Card'
+        sleep 1
+        stripe_iframe = all('iframe[name=stripe_checkout_app]').last
+        Capybara.within_frame stripe_iframe do
+          page.find_field('Email').set 'foo@bar.com'
+          page.find_field('Card number').client_set '4012 8888 8888 1881'
+          page.find_field('MM / YY').client_set '12/42'
+          page.find_field('CVC').set '345'
+          find('button[type="submit"]').click
+        end
+        sleep 5
+        find_by_id('update_cc', visible: false)
+        expect(find_by_id('messages')).to have_text("Successfully updated team #{team.guild_name} credit card.\n\nThank you for your support!")
+      end
+    end
+
     context 'a team without a stripe customer ID' do
       include_context 'team activation'
       let!(:team) { Fabricate(:team, stripe_customer_id: nil) }


### PR DESCRIPTION
Fixes a bug where teams with an expired subscription received "Customer Already Registered" when attempting to re-subscribe.

### Changes

- `subscriptions_endpoint.rb`: Skip the `Customer Already Registered` guard when `subscription_expired_at` is set, allowing expired teams to re-subscribe with a new Stripe customer.
- Added integration test in `subscribe_spec.rb` for re-subscribing an expired team, asserting success and that `subscription_expired_at` is cleared.
- Added integration test in `update_cc_spec.rb` for updating the credit card of a team with an expired subscription.
- Added unit test in `subscriptions_endpoint_spec.rb` for the same scenario.