### PR TITLE
Fix repeated 404 errors when rebragging a deleted Strava activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/03: Fixed repeated 404 errors from Strava when trying to rebrag an activity that was deleted and already unbragged - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Allow teams with an expired subscription to re-subscribe - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/26: Fixed `inform_system!` and `inform_guild_owner!` re-raising Discord errors (e.g. Missing Access) during subscription expiry notifications, causing spurious NewRelic error reports - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/activity.rb
+++ b/discord-strava/models/activity.rb
@@ -16,6 +16,7 @@ class Activity
   field :pr_count, type: Integer
   field :calories, type: Float
   field :bragged_at, type: DateTime
+  field :unbragged_at, type: DateTime
   field :total_elevation_gain, type: Float
   field :private, type: Boolean
   field :visibility, type: String
@@ -31,7 +32,7 @@ class Activity
 
   embeds_one :channel_message, inverse_of: nil
 
-  scope :unbragged, -> { where(bragged_at: nil) }
+  scope :not_bragged, -> { where(bragged_at: nil) }
   scope :bragged, -> { where(:bragged_at.ne => nil) }
 
   belongs_to :team, inverse_of: :activities

--- a/discord-strava/models/user.rb
+++ b/discord-strava/models/user.rb
@@ -162,7 +162,7 @@ class User
   end
 
   def brag_new_activities!
-    activity = activities.unbragged.asc(:start_date).first
+    activity = activities.not_bragged.asc(:start_date).first
     return unless activity
 
     if team.max_activities_per_user_per_day
@@ -274,7 +274,7 @@ class User
   end
 
   def latest_bragged_activity(dt = 12.hours)
-    activities.bragged.where(:start_date.gt => Time.now - dt).desc(:start_date).first
+    activities.bragged.where(unbragged_at: nil, :start_date.gt => Time.now - dt).desc(:start_date).first
   end
 
   def latest_activity_start_date

--- a/discord-strava/models/user_activity.rb
+++ b/discord-strava/models/user_activity.rb
@@ -77,7 +77,7 @@ class UserActivity < Activity
 
       logger.info "Bragging about #{user}, #{self}."
       rc = user.inform!(to_discord(channel_id))
-      update_attributes!(bragged_at: Time.now.utc, channel_message: rc)
+      update_attributes!(bragged_at: Time.now.utc, unbragged_at: nil, channel_message: rc)
       rc
     end
   rescue DiscordStrava::Error => e
@@ -97,7 +97,7 @@ class UserActivity < Activity
 
     logger.info "Rebragging about #{user}, #{self}."
     rc = user.update!(to_discord(channel_message.channel_id), channel_message)
-    update_attributes!(channel_message: rc)
+    update_attributes!(channel_message: rc, unbragged_at: nil)
     rc
   rescue DiscordStrava::Error => e
     raise unless e.message == User::UNKNOWN_MESSAGE_ERROR
@@ -112,7 +112,7 @@ class UserActivity < Activity
 
     logger.info "Unbragging about #{user}, #{self}."
     user.delete!(channel_message)
-    update_attributes!(channel_message: nil)
+    update_attributes!(channel_message: nil, unbragged_at: Time.now.utc)
     nil
   end
 

--- a/spec/models/user_activity_spec.rb
+++ b/spec/models/user_activity_spec.rb
@@ -218,6 +218,13 @@ describe UserActivity do
       expect(activity.rebrag!).to be_nil
       expect(activity.reload.channel_message).to be_nil
     end
+
+    it 'clears unbragged_at' do
+      activity.update_attributes!(unbragged_at: Time.now.utc)
+      allow(Discord::Bot.instance).to receive(:update_message).and_return({ 'id' => '1', 'channel_id' => '2' })
+      activity.rebrag!
+      expect(activity.reload.unbragged_at).to be_nil
+    end
   end
 
   context 'unbrag!' do
@@ -234,6 +241,7 @@ describe UserActivity do
         ).and_return('id' => '1', 'channel_id' => '2')
         expect(activity.unbrag!).to be_nil
         expect(activity.channel_message).to be_nil
+        expect(activity.reload.unbragged_at).not_to be_nil
       end
 
       it 'ignores a previously delete message' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -220,6 +220,21 @@ describe User do
               2.times { user.rebrag! }
             end
           end
+
+          context 'with an unbragged activity (deleted from Strava)' do
+            before do
+              user.activities.bragged.each { |a| a.update_attributes!(unbragged_at: Time.now.utc) }
+            end
+
+            it 'does not include unbragged activities in latest_bragged_activity' do
+              expect(user.send(:latest_bragged_activity)).to be_nil
+            end
+
+            it 'does not rebrag the unbragged activity' do
+              expect(user).not_to receive(:rebrag_activity!)
+              user.rebrag!
+            end
+          end
         end
 
         context 'without a refresh token (until October 2019)', vcr: { cassette_name: 'strava/refresh_access_token' } do


### PR DESCRIPTION
## Problem

After a Strava activity is deleted, the webhook fires `unbrag!` which sets `channel_message: nil` but leaves `bragged_at` intact. The `bragged` scope only checks `bragged_at != nil`, so `latest_bragged_activity` kept returning the deleted activity every rebrag cycle, causing repeated 404 "Record Not Found" errors from the Strava API logged as warnings on every pass.

## Fix

- Added `unbragged_at` DateTime field to `Activity`
- `unbrag!` now sets `unbragged_at: Time.now.utc` alongside clearing `channel_message`
- `rebrag!` and `brag!` clear `unbragged_at: nil`
- Renamed `scope :unbragged` to `scope :not_bragged` to avoid naming conflict with the new field
- `latest_bragged_activity` excludes activities where `unbragged_at` is present

## Tests

- `unbrag!` sets `unbragged_at`
- `rebrag!` clears `unbragged_at`
- `latest_bragged_activity` returns `nil` when all bragged activities have been unbragged
- `rebrag!` does not call `rebrag_activity!` for unbragged activities

Fixes the same issue as dblock/slack-strava#255.