### PR TITLE
Throttle past due subscription notifications to once every 72 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/03: Throttle past due subscription notifications to at most once every 72 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Fixed repeated 404 errors from Strava when trying to rebrag an activity that was deleted and already unbragged - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Allow teams with an expired subscription to re-subscribe - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/02: Fixed `Team#subscription_info` failing with `NoMethodError: undefined method 'sources'` on `Stripe::Customer` in stripe 13.5.1 by using `Stripe::Customer.list_sources` - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/app.rb
+++ b/discord-strava/app.rb
@@ -246,12 +246,15 @@ module DiscordStrava
             logger.info "Checking #{team} subscription to #{subscription_name}, #{subscription.status}."
             case subscription.status
             when 'past_due'
+              next if team.past_due_informed_at && Time.now.utc < team.past_due_informed_at + 72.hours
+
               logger.warn "Subscription for #{team} is #{subscription.status}, notifying."
               team.inform_everyone!("Your subscription to #{subscription_name} is past due. #{team.update_cc_text}")
+              team.update_attributes!(past_due_informed_at: Time.now.utc)
             when 'canceled', 'unpaid'
               logger.warn "Subscription for #{team} is #{subscription.status}, downgrading."
               team.inform_everyone!("Your subscription to #{subscription.plan.nickname} (#{ActiveSupport::NumberHelper.number_to_currency(subscription.plan.amount.to_f / 100)}) was canceled and your team has been downgraded. Thank you for being a customer!")
-              team.update_attributes!(subscribed: false)
+              team.update_attributes!(subscribed: false, past_due_informed_at: nil)
             end
           end
         end

--- a/discord-strava/models/team.rb
+++ b/discord-strava/models/team.rb
@@ -54,6 +54,7 @@ class Team
   field :subscription_expired_at, type: DateTime
 
   field :trial_informed_at, type: DateTime
+  field :past_due_informed_at, type: DateTime
 
   scope :api, -> { where(api: true) }
   scope :striped, -> { where(subscribed: true, :stripe_customer_id.ne => nil) }

--- a/spec/discord-strava/app_spec.rb
+++ b/spec/discord-strava/app_spec.rb
@@ -57,15 +57,36 @@ describe DiscordStrava::App do
         allow(Stripe::Subscription).to receive(:list).and_return([subscription])
         expect_any_instance_of(Team).to receive(:inform_everyone!).with("Your subscription to Plan ($19.99) is past due. #{team.update_cc_text}")
         subject.send(:check_subscribed_teams!)
+        expect(team.reload.past_due_informed_at).not_to be_nil
+      end
+
+      it 'does not re-notify past due subscription within 72 hours' do
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
+        subscription = customer.subscriptions.data.first
+        subscription['status'] = 'past_due'
+        allow(Stripe::Subscription).to receive(:list).and_return([subscription])
+        expect_any_instance_of(Team).not_to receive(:inform_everyone!)
+        subject.send(:check_subscribed_teams!)
+      end
+
+      it 'notifies past due subscription again after 72 hours' do
+        team.update_attributes!(past_due_informed_at: 73.hours.ago)
+        subscription = customer.subscriptions.data.first
+        subscription['status'] = 'past_due'
+        allow(Stripe::Subscription).to receive(:list).and_return([subscription])
+        expect_any_instance_of(Team).to receive(:inform_everyone!).with("Your subscription to Plan ($19.99) is past due. #{team.update_cc_text}")
+        subject.send(:check_subscribed_teams!)
       end
 
       it 'notifies canceled subscription' do
         subscription = customer.subscriptions.data.first
         subscription['status'] = 'canceled'
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
         allow(Stripe::Subscription).to receive(:list).and_return([subscription])
         expect_any_instance_of(Team).to receive(:inform_everyone!).with('Your subscription to Plan ($19.99) was canceled and your team has been downgraded. Thank you for being a customer!')
         subject.send(:check_subscribed_teams!)
         expect(team.reload.subscribed?).to be false
+        expect(team.reload.past_due_informed_at).to be_nil
       end
 
       it 'notifies no active subscriptions' do


### PR DESCRIPTION
Adds a `past_due_informed_at` field to `Team`. When a subscription is `past_due`, the notification is only sent if no notification has been sent in the past 72 hours. The field is cleared when the subscription is canceled/downgraded.
