### PR TITLE
Fix connect! to persist athlete with Mongoid 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/06/23: Fixed `connect!` failing to persist athlete with Mongoid 9.1.0, which changed autosave behavior for unchanged embedded subtrees (MONGOID-5751) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/23: Added Renovate `postUpgradeTasks` to run `bundle install` after Ruby version updates, keeping `Gemfile.lock` in sync - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/23: Added `.ruby-version` as single source of truth for Ruby version, updated CI workflows and Gemfile to read from it so Renovate updates everything - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/05/03: Throttle past due subscription notifications to at most once every 72 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/discord-strava/models/user.rb
+++ b/discord-strava/models/user.rb
@@ -91,8 +91,8 @@ class User
     raise 'Missing refresh_token in OAuth response.' unless response.refresh_token
     raise 'Missing expires_at in OAuth response.' unless response.expires_at
 
-    create_athlete(Athlete.summary_attrs_from_strava(response.athlete))
     update_attributes!(
+      athlete: Athlete.new(Athlete.summary_attrs_from_strava(response.athlete)),
       token_type: response.token_type,
       access_token: response.access_token,
       refresh_token: response.refresh_token,


### PR DESCRIPTION
Mongoid 9.1.0 ([MONGOID-5751](https://jira.mongodb.org/browse/MONGOID-5751)) changed autosave to skip unchanged embedded subtrees. The previous code called `create_athlete` then `update_attributes!` with only token fields — the new athlete was set in-memory but never written to the database.

Fix by merging the athlete into the single `update_attributes!` call.