### PR TITLE
Disable Renovate ruby-version manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/06/23: Disabled Renovate ruby-version manager — Ruby upgrades require manual `bundle install` to keep `Gemfile.lock` in sync - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/23: Fixed `connect!` failing to persist athlete with Mongoid 9.1.0, which changed autosave behavior for unchanged embedded subtrees (MONGOID-5751) - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/23: Added Renovate `postUpgradeTasks` to run `bundle install` after Ruby version updates, keeping `Gemfile.lock` in sync - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/06/23: Added `.ruby-version` as single source of truth for Ruby version, updated CI workflows and Gemfile to read from it so Renovate updates everything - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "postUpgradeTasks": {
-    "commands": ["bundle install"],
-    "fileFilters": ["Gemfile.lock"],
-    "executionMode": "branch"
-  },
   "packageRules": [
     {
       "matchManagers": [
@@ -29,6 +24,12 @@
         "major"
       ],
       "groupName": "github actions"
+    },
+    {
+      "matchManagers": [
+        "ruby-version"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Renovate's `postUpgradeTasks` cannot run `bundle install` on the GitHub App (`allowedCommands` is not configurable). Disabling the `ruby-version` manager so Ruby upgrades are handled manually — bump `.ruby-version` and run `bundle install` by hand.